### PR TITLE
Update docker resolver with support for redirects 

### DIFF
--- a/vendor/github.com/containers/image/v5/docker/docker_client.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_client.go
@@ -545,6 +545,16 @@ func (c *dockerClient) makeRequestToResolvedURLOnce(ctx context.Context, method,
 			return nil, err
 		}
 	}
+
+	if c.client.CheckRedirect == nil {
+		c.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			return errors.Wrap(c.setupRequestAuth(req, extraScope), "failed to authorize redirect")
+		}
+	}
+
 	logrus.Debugf("%s %s", method, url)
 	res, err := c.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Authorizes the request in case the host is redirected, supporting at most 10 redirects.
Inspired in the containerd's implementation for supporting redirects.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Updates the docker resolver logic to authorize the request in case the host is redirected.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
